### PR TITLE
wip: Add AWS S3 region option

### DIFF
--- a/aws/index.js
+++ b/aws/index.js
@@ -2,9 +2,30 @@
 
 var Rx = require('rx');
 var s3 = require('s3');
-var client = s3.createClient({});
+
+// Singleton so only one S3 client is used.
+var getClient = (function () {
+  function createS3Client(region) {
+    return s3.createClient({
+      s3Options: {
+        region: region
+      }
+    });
+  }
+  var instance = null;
+  return {
+    setRegion: function(region) {
+      if (instance === null) {
+        instance = createS3Client(region);
+      }
+      return instance;
+    }
+  };
+})();
 
 var uploader = function (remotePath, options) {
+  var client = getClient.setRegion(options.region);
+
   return Rx.Observable.create(function (observer) {
     var params = {
       localDir: options.localPath,

--- a/aws/index.js
+++ b/aws/index.js
@@ -3,28 +3,12 @@
 var Rx = require('rx');
 var s3 = require('s3');
 
-// Singleton so only one S3 client is used.
-var getClient = (function () {
-  function createS3Client(region) {
-    return s3.createClient({
-      s3Options: {
-        region: region
-      }
-    });
-  }
-  var instance = null;
-  return {
-    setRegion: function(region) {
-      if (instance === null) {
-        instance = createS3Client(region);
-      }
-      return instance;
-    }
-  };
-})();
+var client = null;
 
 var uploader = function (remotePath, options) {
-  var client = getClient.setRegion(options.region);
+  if (client === null) {
+    client = createS3Client(options.region);
+  }
 
   return Rx.Observable.create(function (observer) {
     var params = {
@@ -52,3 +36,11 @@ var uploader = function (remotePath, options) {
 module.exports = {
   uploader: uploader
 };
+
+function createS3Client(region) {
+  return s3.createClient({
+    s3Options: {
+      region: region
+    }
+  });
+}

--- a/configuration/index.js
+++ b/configuration/index.js
@@ -11,6 +11,7 @@ module.exports = function (pkgInfo) {
     localPath: config.localPath || 'dist',
     remoteBasePath: config.remoteBasePath || 'js',
     bucket: config.bucket,
+    region: config.region,
     cdn: config.cdn,
     mainBundleFile: config.mainBundleFile,
     majorAndMinor: config.majorAndMinor !== false,


### PR DESCRIPTION
# WIP

If the region option of the AWS S3 Client is missing and the bucket isn't on the default region you get this error:
```
Unable to sync: PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
```

The solution is setting the correct S3 region. More info: http://stackoverflow.com/a/26725760/4709891