### PR TITLE
Added version override argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ options
 * --snapshot-name (string) name used for snapshot. Default is 'development'
 * --silent run in silent mode
 * --trace run with verbose log
+* --version-override (string) indicate semantic version number to upload (overrides package.json version)
 
 ### types
 

--- a/bin/ccu
+++ b/bin/ccu
@@ -17,11 +17,12 @@ var cli = meow(`
     --snapshot-name (string) name used for snapshot. Default is 'development'
     --silent run in silent mode
     --trace run with verbose log
+    --version-override (string) indicate semantic version number to upload (overrides package.json version)
 
   Examples
   $ ccu dist
 `, {
-  string: ['type', 'snapshotName'],
+  string: ['type', 'snapshotName', 'versionOverride'],
   boolean: ['dry', 'onlyFull', 'silent', 'trace'],
   alias: {
     t: 'type',
@@ -52,5 +53,6 @@ var levels = ['debug', 'info', 'warn', 'error', 'success']
   });
 options.logLevels = levels;
 options.snapshotName = cli.flags.snapshotName || options.snapshotName;
+options.version = cli.flags.versionOverride || options.version;
 
 upload(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/component-cdn-uploader",
-  "version": "2.3.0",
+  "version": "2.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/component-cdn-uploader",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

This PR adds the option to specify a semantic version number that overrides the one found in package.json when using ccu.

Not a breaking change as it only adds an optional argument to the command.

### References



### Testing

Tested locally. It can be tested by using the command with and without the new --version-override argument, including the --trace flag (for verbose logs) and the --dry flag and inspecting the logs.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
